### PR TITLE
Single touch cancellation

### DIFF
--- a/CustomInputEvents/InputEventSingleScreenTouch.gd
+++ b/CustomInputEvents/InputEventSingleScreenTouch.gd
@@ -1,12 +1,14 @@
 class_name InputEventSingleScreenTouch
 extends InputEventAction
 
-var position
+var position : Vector2
+var cancelled : bool
 
-func _init(e):
+func _init(e : InputEventScreenTouch, cancel : bool):
 	position = e.position
 	pressed = e.pressed
+	cancelled = cancel
 
 
 func as_text():
-	return "InputEventSingleScreenTouch : position=" + str(position) + ", pressed=" + str(pressed)
+	return "InputEventSingleScreenTouch : position=" + str(position) + ", pressed=" + str(pressed) + ", cancelled=" + str(cancelled)

--- a/InputManager.gd
+++ b/InputManager.gd
@@ -83,9 +83,10 @@ func _unhandled_input(event):
 				first_touch = event
 				if tap_delay_timer.is_stopped(): tap_delay_timer.start(TAP_TIME_THRESHOLD)
 			else:
-				single_touch_cancelled = true
 				cancel_single_drag()
-				emit("single_touch", InputEventSingleScreenTouch.new(first_touch, true))
+				if !single_touch_cancelled :
+					single_touch_cancelled = true
+					emit("single_touch", InputEventSingleScreenTouch.new(first_touch, true))
 		else:
 			touches.erase(event.get_index())
 			drags.erase(event.get_index())

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ When a gesture is detected [`_input(InputEvent event)`](https://docs.godotengine
 |-----------------------------------------------------------------------------------------|--------------|------------------------------------------------------------------------|
 | [Vector2](https://docs.godotengine.org/en/3.1/classes/class_vector2.html#class-vector2) | position     | Tap position.                                                          |
 | [boolean](https://docs.godotengine.org/en/3.0/classes/class_bool.html)                  | pressed      | If it is `true`, the touch is beginning. If it is `false`, the touch is ending.  |
+| [boolean](https://docs.godotengine.org/en/3.0/classes/class_bool.html)                  | cancelled    | If it is `true`, the touch has been cancelled by another touch. If it is `false`, the touch is still the only one.  |
 
 ### Mouse to gesture
 To enable single finger gestures go to **Project > Project Settings > Input Devices > Pointing** and turn on *Emulate Touch From Mouse* to emulate a single finger press with the left click. For the other gestures 


### PR DESCRIPTION
Like discussed in previous PR #14 , add an cancelled property to notify the user that a single touch is "cancelled" by another touch press, as well have the possibility to get the release event of the single touch after being "cancelled".
Note that to behave like previously, existing code needs to test cancelled property equals false first.