### PR TITLE
fix error caused by orphaned released events.

### DIFF
--- a/InputManager.gd
+++ b/InputManager.gd
@@ -144,7 +144,8 @@ func _handle_mouse_motion(event : InputEventMouseMotion) -> void:
 		_emit("twist", twist_event)
 
 func _handle_screen_touch(event : InputEventScreenTouch) -> void:
-	raw_gesture._update_screen_touch(event)
+	if not raw_gesture._update_screen_touch(event):
+		return
 	_emit("raw_gesture", raw_gesture)
 	var index : int = event.index
 	if event.pressed:

--- a/RawGesture.gd
+++ b/RawGesture.gd
@@ -177,7 +177,9 @@ func _update_screen_drag(event : InputEventScreenDrag, time : float = -1) -> voi
 	drags[event.index] = drag
 	elapsed_time = time - start_time
 	
-func _update_screen_touch(event : InputEventScreenTouch, time : float = -1) -> void:
+# returns true if the event can be handled, false if it
+# should be skipped.
+func _update_screen_touch(event : InputEventScreenTouch, time : float = -1) -> bool:
 	if time < 0:
 		time = Util.now()
 	var touch : Touch = Touch.new()
@@ -194,11 +196,14 @@ func _update_screen_touch(event : InputEventScreenTouch, time : float = -1) -> v
 		if active_touches == 1:
 			start_time = time
 	else:
+		if not event.index in presses:
+			return false
 		_add_history(event.index, "releases", touch)
 		releases[event.index] = touch
 		active_touches -= 1
 		drags.erase(event.index)
 	elapsed_time = time - start_time
+	return true
 
 func _add_history(index : int, type : String, value) -> void:
 	if !history.has(index): 


### PR DESCRIPTION
I've turned "Emulate Mouse From Touch" off in the Godot settings and for
some reason, Button controls like to steal/consume the initial touch
pressed event and then ignore the released event. What does this result
in?

Well this causes the InputManager to break because it expects every
`pressed` to have a matching `released`. Perhaps this assumption/issue needs
to be sorted out but I've made a quick patch that ignores released
events when there is no matching pressed event.

Because of https://github.com/godotengine/godot/issues/24589
Buttons don't really work with touch so in my project, I've added a
custom script. I noticed @Calinou commented on this issue referring to
Godot Touch Input Manager as a possible solution. Should Godot Touch
Input Manager have some sort of GUI Controls integration that fixes
this? or is this a Godot engine issue? something to think about.