### PR TITLE
Change InputManager event handling to _input

### DIFF
--- a/InputManager.gd
+++ b/InputManager.gd
@@ -126,7 +126,7 @@ func _ready() -> void:
 		# _set_default_action("twist_clockwise"        , _native_mouse_button_event(MOUSE_BUTTON_WHEEL_UP)) # TODO
 		# _set_default_action("twist_counterclockwise" , _native_mouse_button_event(MOUSE_BUTTON_WHEEL_DOWN)) # TODO
 
-func _unhandled_input(event : InputEvent) -> void:
+func _input(event : InputEvent) -> void:
 	if event is InputEventScreenDrag:
 		_handle_screen_drag(event)
 	elif event is InputEventScreenTouch:


### PR DESCRIPTION
Should allow `_gui_input` to work (#38) and also allow more flexibility in how to handle events.

Related documentation: https://docs.godotengine.org/en/stable/tutorials/inputs/inputevent.html#how-does-it-work